### PR TITLE
Update Cargo.toml to fix loong arch build for snappy

### DIFF
--- a/librocksdb_sys/libtitan_sys/Cargo.toml
+++ b/librocksdb_sys/libtitan_sys/Cargo.toml
@@ -24,5 +24,5 @@ cc = "1.0.3"
 cmake = "0.1"
 
 [dependencies.snappy-sys]
-git = "https://github.com/tikv/rust-snappy.git"
-branch = "static-link"
+git = "https://github.com/lance6716/rust-snappy.git"
+branch = "static-link-loong64"


### PR DESCRIPTION
https://github.com/lance6716/rust-snappy/commit/24d7fa1f89f38f6436ebc72746eb41cc2d323e74